### PR TITLE
Make SpriteOutline shader

### DIFF
--- a/Assets/_Scripts/SpriteOutlineRenderer.cs
+++ b/Assets/_Scripts/SpriteOutlineRenderer.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using UnityEngine;
+
+[ExecuteInEditMode][RequireComponent(typeof(SpriteRenderer))]
+public class SpriteOutlineRenderer : MonoBehaviour
+{
+    public Color color = Color.white;
+
+    [Range(0, 16)][SerializeField]
+    int outlineSize = 1;
+
+    private SpriteRenderer spriteRenderer;
+
+    private void OnEnable()
+    {
+        spriteRenderer = GetComponent<SpriteRenderer>();
+        UpdateOutline(true);
+    }
+
+    private void OnDisable()
+    {
+        UpdateOutline(false);
+    }
+
+    private void Update()
+    {
+        UpdateOutline(true);
+    }
+
+    private void UpdateOutline(bool outline)
+    {
+        MaterialPropertyBlock mpb = new MaterialPropertyBlock();
+        spriteRenderer.GetPropertyBlock(mpb);
+        mpb.SetFloat("_Outline", outline ? 1f : 0f);
+        mpb.SetColor("_OutlineColor", color);
+        mpb.SetFloat("_OutlineSize", outlineSize);
+        spriteRenderer.SetPropertyBlock(mpb);
+    }
+}

--- a/Assets/_Scripts/SpriteOutlineRenderer.cs.meta
+++ b/Assets/_Scripts/SpriteOutlineRenderer.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 052d315ed98e45dea444893dd4d02bfc
+timeCreated: 1627121463

--- a/Assets/_Shader.meta
+++ b/Assets/_Shader.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 87a29169a90b9ae4da43c4654f3aca61
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Shader/Sprite-Outline.shader
+++ b/Assets/_Shader/Sprite-Outline.shader
@@ -1,0 +1,81 @@
+Shader "Sprites/Outline"
+{
+    Properties
+    {
+        [PerRendererData] _MainTex ("Sprite Texture", 2D) = "white" {}
+        _Color ("Tint", Color) = (1,1,1,1)
+        [MaterialToggle] PixelSnap ("Pixel snap", Float) = 0
+        [HideInInspector] _RendererColor ("RendererColor", Color) = (1,1,1,1)
+        [HideInInspector] _Flip ("Flip", Vector) = (1,1,1,1)
+        [PerRendererData] _AlphaTex ("External Alpha", 2D) = "white" {}
+        [PerRendererData] _EnableExternalAlpha ("Enable External Alpha", Float) = 0
+
+        // Add values to determine if outlining is enabled and outline color.
+        [PerRendererData] _Outline("Outline", Float) = 0
+        [PerRendererData] _OutlineColor("Outline Color", Color) = (1,1,1,1)
+        [PerRendererData] _OutlineSize("Outline Size", int) = 1
+    }
+
+    SubShader
+    {
+        Tags
+        { 
+            "Queue"="Transparent" 
+            "IgnoreProjector"="True" 
+            "RenderType"="Transparent" 
+            "PreviewType"="Plane"
+            "CanUseSpriteAtlas"="True"
+        }
+
+        Cull Off
+        Lighting Off
+        ZWrite Off
+        Blend One OneMinusSrcAlpha
+
+        Pass
+        {
+        CGPROGRAM
+            #pragma vertex SpriteVert
+            #pragma fragment frag
+            #pragma target 2.0
+            #pragma multi_compile_instancing
+            #pragma multi_compile _ PIXELSNAP_ON
+            #pragma multi_compile _ ETC1_EXTERNAL_ALPHA
+            #include "UnitySprites.cginc"
+
+            float _Outline;
+            fixed4 _OutlineColor;
+            int _OutlineSize;
+            float4 _MainTex_TexelSize;
+
+            fixed4 frag(v2f IN) : SV_Target
+            {
+                fixed4 c = SampleSpriteTexture(IN.texcoord) * IN.color;
+
+                // If outline is enabled and there is a pixel, try to draw an outline.
+                if (_Outline > 0 && c.a != 0) {
+                    float totalAlpha = 1.0;
+
+                    [unroll(16)]
+                    for (int i = 1; i < _OutlineSize + 1; i++) {
+                        fixed4 pixelUp = tex2D(_MainTex, IN.texcoord + fixed2(0, i * _MainTex_TexelSize.y));
+                        fixed4 pixelDown = tex2D(_MainTex, IN.texcoord - fixed2(0,i *  _MainTex_TexelSize.y));
+                        fixed4 pixelRight = tex2D(_MainTex, IN.texcoord + fixed2(i * _MainTex_TexelSize.x, 0));
+                        fixed4 pixelLeft = tex2D(_MainTex, IN.texcoord - fixed2(i * _MainTex_TexelSize.x, 0));
+
+                        totalAlpha = totalAlpha * pixelUp.a * pixelDown.a * pixelRight.a * pixelLeft.a;
+                    }
+
+                    if (totalAlpha == 0) {
+                        c.rgba = fixed4(1, 1, 1, 1) * _OutlineColor;
+                    }
+                }
+
+                c.rgb *= c.a;
+
+                return c;
+            }
+        ENDCG
+        }
+    }
+}

--- a/Assets/_Shader/Sprite-Outline.shader.meta
+++ b/Assets/_Shader/Sprite-Outline.shader.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: d223d0a519712c2408f835ff14dd1b62
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  preprocessorOverride: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Shader/SpriteOutline.mat
+++ b/Assets/_Shader/SpriteOutline.mat
@@ -1,0 +1,89 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: SpriteOutline
+  m_Shader: {fileID: 4800000, guid: d223d0a519712c2408f835ff14dd1b62, type: 3}
+  m_ShaderKeywords: ETC1_EXTERNAL_ALPHA
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _AlphaTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Floats:
+    - PixelSnap: 0
+    - _BumpScale: 1
+    - _Cutoff: 0.5
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 0
+    - _EnableExternalAlpha: 0
+    - _GlossMapScale: 1
+    - _Glossiness: 0.5
+    - _GlossyReflections: 1
+    - _Metallic: 0
+    - _Mode: 0
+    - _OcclusionStrength: 1
+    - _Outline: 0
+    - _OutlineSize: 1
+    - _Parallax: 0.02
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _UVSec: 0
+    - _ZWrite: 1
+    m_Colors:
+    - _Color: {r: 1, g: 1, b: 1, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+    - _Flip: {r: 1, g: 1, b: 1, a: 1}
+    - _OutlineColor: {r: 1, g: 1, b: 1, a: 1}
+    - _RendererColor: {r: 1, g: 1, b: 1, a: 1}
+  m_BuildTextureStacks: []

--- a/Assets/_Shader/SpriteOutline.mat.meta
+++ b/Assets/_Shader/SpriteOutline.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2e291aac523fd8549b993542097e0e90
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
```
1. _Shader/Sprite-Outline.shader
2. _Shader/SpriteOutline.material
3. _Scripts/SpriteOutlineRenderer.cs
```
`SpriteRenderer`에 호환되는 쉐이더로, 사용 방법은 다음과 같습니다.
1. 오브젝트에 `SpriteOutlineRenderer` 컴포넌트를 추가한다.
2. 인스펙터에서 원하는 색상, 외곽선의 크기를 선택한다.
3. 그러면 아무때나 작동한다. 끝.